### PR TITLE
Updated Chainsaw FAQ and moved it to correct bullet point

### DIFF
--- a/docs/core_rules/faq_281123.md
+++ b/docs/core_rules/faq_281123.md
@@ -1355,7 +1355,7 @@ The errata are updated regularly; when changes are made any changes from the pre
 
 * **Page 84 - Chainsaw**
 
-- Add the following to the fourth bullet point:
+- Add the following to the second bullet point:
 
 *This will result in a Turnover.*
 

--- a/docs/core_rules/skills_and_traits.md
+++ b/docs/core_rules/skills_and_traits.md
@@ -478,9 +478,9 @@ Instead of performing a Block action (on its own or as part of a Blitz action), 
 To perform a Chainsaw Attack Special action, roll a D6:
 
 * On a roll of 2+, the nominated target is hit by a Chainsaw!
-* On a roll of 1, the Chainsaw will violently 'kick-back' and hit the player wielding it.
+* On a roll of 1, the Chainsaw will violently 'kick-back' and hit the player wielding it. <span style="color: darkmagenta">This will result in a Turnover.</span>
 * In either case, an Armour roll is made against the player hit by the Chainsaw, adding +3 to the result.
-* If the armour of the player hit is broken, they become Prone and an Injury roll is made against them. This Injury roll cannot be modified in any way. <span style="color: darkmagenta">This will result in a Turnover.</span>
+* If the armour of the player hit is broken, they become Prone and an Injury roll is made against them. This Injury roll cannot be modified in any way. 
 * If the armour of the player hit is not broken, this Trait has no effect.
 
 This player can only use the Chainsaw once per turn (i.e., a Chainsaw cannot be used with Frenzy or Multiple Block) and if used as part of a Blitz action, this player cannot continue moving after using it.


### PR DESCRIPTION
Had some misunderstanding at a game the other day with chainsaws. This fix corrects a typo that GW made in an FAQ. The turnover sentence was supposed to be on the 2nd bullet point, not the 4th. Can be seen on page 13 of most current FAQ

https://www.warhammer-community.com/wp-content/uploads/2017/11/P9GJXUTdGyGDeZkk.pdf